### PR TITLE
Updates the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,19 +114,31 @@ By default if translation for the specified key is not present the key itself is
 to help you find the missing translation.
 This behaviour can be augmented by passing custom ``notFound`` value to setText options or MDText contructor.
 
-This value can be either a string, or a function of type `string => string`.
+This value can be either a string, or a function of type `string -> string`. 
+If it is a string, then it will be returned as is any time a key is missing.
+If you provide a function, then the function will be run with the missing key
+as its only arguments.
 
 ```
-  T.setTexts(translations, {
-    notFound: (key: string) => {
-      return `${key} <-- this guy`
-    }
-  })
+// "Not Found!" will replace all missing translations 
+T.setTexts(translations, {
+  notFound: 'Not Found!'
+})
+  
+// "SomeKey <-- this guy" will appear instead
+T.setTexts(translations, {
+  notFound: (key: string) => {
+    return `${key} <-- this guy`
+  }
+})
+  
+// you can combine this solution with markdown!
+T.setTexts(translations, {
+  notFound: (key: string) => {
+    return `**${key}**` // will render <strong>SomeKey</strong>
+  }
+})
 ```
-
-If you provide a key with no corresponding translation, it will renders as.
-
-> SomeKey <-- this guy
 
 ### Markdown syntax
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If it is a string, then it will be returned as is any time a key is missing.
 If you provide a function, then the function will be run with the missing key
 as its only arguments.
 
-```
+```js
 // "Not Found!" will replace all missing translations 
 T.setTexts(translations, {
   notFound: 'Not Found!'
@@ -127,14 +127,14 @@ T.setTexts(translations, {
   
 // "SomeKey <-- this guy" will appear instead
 T.setTexts(translations, {
-  notFound: (key: string) => {
+  notFound: key => {
     return `${key} <-- this guy`
   }
 })
   
 // you can combine this solution with markdown!
 T.setTexts(translations, {
-  notFound: (key: string) => {
+  notFound: key => {
     return `**${key}**` // will render <strong>SomeKey</strong>
   }
 })

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ By default if translation for the specified key is not present the key itself is
 to help you find the missing translation.
 This behaviour can be augmented by passing custom ``notFound`` value to setText options or MDText contructor.
 
+This value can be either a string, or a function of type `string => string`.
+
+```
+  T.setTexts(translations, {
+    notFound: (key: string) => {
+      return `${key} <-- this guy`
+    }
+  })
+```
+
+If you provide a key with no corresponding translation, it will renders as.
+
+> SomeKey <-- this guy
+
 ### Markdown syntax
 
  + ``*italic*`` *italic*  - ``<em>`` **breaking change V1, ``<strong>`` in V0**
@@ -125,7 +139,7 @@ This behaviour can be augmented by passing custom ``notFound`` value to setText 
  + ``\n`` New Line ``<br>``
  + ``[Paragraph 1][Paragraph 2]`` Multiple paragraphs ``<p>``
  + ``#``-``####`` Headers ``<h1>-<h4>``
- + \`\` \*as*\_[IS]_ \`\`  Literal  *new - V1*
+ + \`\` \*as\*\_[IS]\_ \`\`  Literal  *new - V1*
 
 ### Unit tests are half-loaf documentation
 You are welcomed to consult examples folder and unit tests for usage details and examples.


### PR DESCRIPTION
I've written the readme assuming that this:

```
key => {
  return `**${key}**`
}
```

Will render **SomeKey** after formatting.